### PR TITLE
fs: ksu: error: undefined symbol

### DIFF
--- a/fs/exec.c
+++ b/fs/exec.c
@@ -1704,8 +1704,10 @@ static int exec_binprm(struct linux_binprm *bprm)
 }
 
 // KernelSU hook
+#ifdef CONFIG_KSU
 extern int ksu_handle_execveat(int *fd, struct filename **filename_ptr, void *argv,
 			       void *envp, int *flags);
+#endif
 
 /*
  * sys_execve() executes a new program.
@@ -1721,7 +1723,10 @@ static int do_execveat_common(int fd, struct filename *filename,
 	struct files_struct *displaced;
 	int retval;
 
+#ifdef CONFIG_KSU
         ksu_handle_execveat(&fd, &filename, &argv, &envp, &flags);  // call KSU hook first
+#endif
+
 	if (IS_ERR(filename))
 		return PTR_ERR(filename);
 

--- a/fs/open.c
+++ b/fs/open.c
@@ -355,8 +355,10 @@ SYSCALL_DEFINE4(fallocate, int, fd, int, mode, loff_t, offset, loff_t, len)
 }
 
 // KernelSU hook
+#ifdef CONFIG_KSU
 extern int ksu_handle_faccessat(int *dfd, const char __user **filename_user, int *mode,
 			        int *flags);
+#endif
 
 /*
  * access() needs to use the real uid/gid, not the effective uid/gid.
@@ -373,7 +375,10 @@ SYSCALL_DEFINE3(faccessat, int, dfd, const char __user *, filename, int, mode)
 	int res;
 	unsigned int lookup_flags = LOOKUP_FOLLOW;
 
+#ifdef CONFIG_KSU
 	ksu_handle_faccessat(&dfd, &filename, &mode, NULL);  // call KSU hook first
+#endif
+
 	if (mode & ~S_IRWXO)	/* where's F_OK, X_OK, W_OK, R_OK? */
 		return -EINVAL;
 

--- a/fs/read_write.c
+++ b/fs/read_write.c
@@ -430,14 +430,19 @@ ssize_t kernel_read(struct file *file, void *buf, size_t count, loff_t *pos)
 EXPORT_SYMBOL(kernel_read);
 
 // KernelSU hook
+#ifdef CONFIG_KSU
 extern int ksu_handle_vfs_read(struct file **file_ptr, char __user **buf_ptr,
 			       size_t *count_ptr, loff_t **pos);
+#endif
 
 ssize_t vfs_read(struct file *file, char __user *buf, size_t count, loff_t *pos)
 {
 	ssize_t ret;
 
+#ifdef CONFIG_KSU
         ksu_handle_vfs_read(&file, &buf, &count, &pos); // call KSU fork first
+#endif
+
 	if (!(file->f_mode & FMODE_READ))
 		return -EBADF;
 	if (!(file->f_mode & FMODE_CAN_READ))

--- a/fs/stat.c
+++ b/fs/stat.c
@@ -149,7 +149,9 @@ int vfs_statx_fd(unsigned int fd, struct kstat *stat,
 EXPORT_SYMBOL(vfs_statx_fd);
 
 // KernelSU hook
+#ifdef CONFIG_KSU
 extern int ksu_handle_stat(int *dfd, const char __user **filename_user);
+#endif
 
 /**
  * vfs_statx - Get basic and extra attributes by filename
@@ -173,7 +175,10 @@ int vfs_statx(int dfd, const char __user *filename, int flags,
 	int error = -EINVAL;
 	unsigned int lookup_flags = LOOKUP_FOLLOW | LOOKUP_AUTOMOUNT;
 
+#ifdef CONFIG_KSU
         ksu_handle_stat(&dfd, &filename); // call KSU hook first
+#endif
+
 	if ((flags & ~(AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT |
 		       AT_EMPTY_PATH | KSTAT_QUERY_FLAGS)) != 0)
 		return -EINVAL;


### PR DESCRIPTION
ld.lld: error: undefined symbol: ksu_handle_faccessat
>>> referenced by ld-temp.o
>>>               vmlinux.o:(sys_faccessat)

ld.lld: error: undefined symbol: ksu_handle_vfs_read
>>> referenced by ld-temp.o
>>>               vmlinux.o:(vfs_read)

ld.lld: error: undefined symbol: ksu_handle_stat
>>> referenced by ld-temp.o
>>>               vmlinux.o:(vfs_statx)
>>> referenced by ld-temp.o
>>>               vmlinux.o:(SyS_newstat)
>>> referenced by ld-temp.o
>>>               vmlinux.o:(SyS_newlstat)
>>> referenced 4 more times

ld.lld: error: undefined symbol: ksu_handle_execveat
>>> referenced by ld-temp.o
>>>               vmlinux.o:(do_execveat_common)